### PR TITLE
[로그인] 로그인 API 연동 및 axios instance 설정

### DIFF
--- a/src/apis/client.ts
+++ b/src/apis/client.ts
@@ -2,12 +2,48 @@ import axios from 'axios';
 
 const BASE_URL: string = import.meta.env.VITE_BASE_URL;
 
+export const getAccessToken = () => {
+  const accessToken = localStorage.getItem('accessToken');
+  return accessToken ? `Bearer ${accessToken}` : '';
+};
+
 const instance = axios.create({
   baseURL: BASE_URL,
   timeout: 5000,
   headers: {
     'Content-Type': 'application/json',
   },
+  withCredentials: true,
 });
+
+instance.interceptors.request.use((config) => {
+  config.headers.Authorization = getAccessToken();
+  return config;
+});
+
+instance.interceptors.response.use(
+  (res) => {
+    // undefined 출력.. 서버에서 접근 가능하도록 처리해주셔야 할듯
+    // console.log('x-access-token:', res.headers['x-access-token']);
+
+    // access 토큰 만료된 경우 서버에서 'X-Access-Token' 헤더로 재발급된 토큰 전송
+    if ('x-access-token' in res.headers) {
+      const newToken = res.headers['x-access-token'];
+      localStorage.setItem('accessToken', newToken);
+    }
+    return res;
+  },
+  (error) => {
+    // 401: access 토큰이 없는 경우, 403: refresh 토큰이 없는 경우
+    if (error.response?.status === 401 || error.response?.status === 403) {
+      localStorage.removeItem('accessToken');
+
+      // 로그인 페이지로 리다이렉트
+      alert('로그인이 필요합니다.');
+      window.location.replace('/login');
+    }
+    return Promise.reject(error);
+  },
+);
 
 export default instance;

--- a/src/components/OnboardingSection/OnboardingSection.style.ts
+++ b/src/components/OnboardingSection/OnboardingSection.style.ts
@@ -1,26 +1,24 @@
 import styled from 'styled-components';
 
+export const OnboardingContainer = styled.div`
+  ${({ theme: { mixin } }) => mixin.flexCenter()};
+  gap: 5.1rem;
+`;
+
 // 디자인 완료 후 로고 파일로 대체
 export const LogoWrapper = styled.div`
-  width: 11.5625rem;
-  height: 11.5625rem;
-  flex-shrink: 0;
-  margin-bottom: 3.19rem;
-  background-color: gray;
+  width: 18.5rem;
+  height: 18.5rem;
+  background-color: ${({ theme }) => theme.colors.gray};
 `;
 
 export const DescriptionWrapper = styled.div`
-  width: 18.9375rem;
-  height: 3.75rem;
-  flex-shrink: 0;
-  margin-bottom: 4.44rem;
+  color: ${({ theme }) => theme.colors.white};
   text-align: center;
-  font-size: 1.5rem;
-  font-weight: 500;
-  line-height: 2.3125rem;
-  letter-spacing: -0.02rem;
+  font-size: 24px;
+  line-height: 37px;
 `;
 
 export const BoldSpan = styled.span`
-  font-weight: 800;
+  font-size: 26px;
 `;

--- a/src/components/OnboardingSection/OnboardingSection.tsx
+++ b/src/components/OnboardingSection/OnboardingSection.tsx
@@ -2,14 +2,14 @@ import * as S from './OnboardingSection.style';
 
 const OnboardingSection = () => {
   return (
-    <>
+    <S.OnboardingContainer>
       <S.LogoWrapper />
       <S.DescriptionWrapper>
         당신의 중요한 <S.BoldSpan>모멘트</S.BoldSpan>를
         <br />
         기록하고, 달성하세요.
       </S.DescriptionWrapper>
-    </>
+    </S.OnboardingContainer>
   );
 };
 

--- a/src/hooks/queries/useLogin.tsx
+++ b/src/hooks/queries/useLogin.tsx
@@ -3,15 +3,32 @@ import { useNavigate } from 'react-router-dom';
 import { useMutation } from '@tanstack/react-query';
 import instance from '../../apis/client';
 
-interface LoginResponse {
+interface UserResponse {
+  user: {
+    id: string;
+    userID: string;
+    email: string;
+    nickname: string;
+    friendCode: string;
+    profileImageUrl: string;
+  };
   accessToken: string;
-  refreshToken: string;
 }
 
-const fetchKakaoLogin = async (code: string): Promise<LoginResponse> => {
-  // API path 백엔드 구현 후 수정 필요!
-  const response = await instance.get(`/member/oauth/kakao?code=${code}`);
-  return response.data;
+const fetchUser = async (token: string): Promise<UserResponse> => {
+  const userResponse = await instance.post('/auth/kakao-login/user', {
+    kakaoAccessToken: token,
+  });
+
+  return userResponse.data;
+};
+
+const fetchKakaoLogin = async (code: string): Promise<UserResponse> => {
+  const response = await instance.post('/auth/kakao-login', {
+    code: code,
+  });
+  const kakaoToken = response.data.access_token;
+  return fetchUser(kakaoToken);
 };
 
 const useLogin = (code: string | null) => {
@@ -22,16 +39,15 @@ const useLogin = (code: string | null) => {
     onSuccess: (data) => {
       // 토큰을 로컬 스토리지에 저장
       localStorage.setItem('accessToken', data.accessToken);
-      localStorage.setItem('refreshToken', data.refreshToken);
 
       // 로그인 성공 시 페이지 완전 리로드
-      window.location.replace('/');
+      window.location.replace('/home');
     },
     onError: (error) => {
       console.error('Login failed:', error);
 
       // 에러 메세지 확인을 위해 navigate 사용
-      navigate('/');
+      navigate('/login');
     },
   });
 

--- a/src/hooks/queries/useLogin.tsx
+++ b/src/hooks/queries/useLogin.tsx
@@ -16,11 +16,10 @@ interface UserResponse {
 }
 
 const fetchUser = async (token: string): Promise<UserResponse> => {
-  const userResponse = await instance.post('/auth/kakao-login/user', {
+  const response = await instance.post('/auth/kakao-login/user', {
     kakaoAccessToken: token,
   });
-
-  return userResponse.data;
+  return response.data;
 };
 
 const fetchKakaoLogin = async (code: string): Promise<UserResponse> => {
@@ -37,16 +36,12 @@ const useLogin = (code: string | null) => {
   const loginMutation = useMutation({
     mutationFn: (code: string) => fetchKakaoLogin(code),
     onSuccess: (data) => {
-      // 토큰을 로컬 스토리지에 저장
       localStorage.setItem('accessToken', data.accessToken);
-
-      // 로그인 성공 시 페이지 완전 리로드
-      window.location.replace('/home');
+      // 콜백 페이지 기록 삭제
+      navigate('/home', { replace: true });
     },
     onError: (error) => {
       console.error('Login failed:', error);
-
-      // 에러 메세지 확인을 위해 navigate 사용
       navigate('/login');
     },
   });

--- a/src/pages/Login/Login.style.ts
+++ b/src/pages/Login/Login.style.ts
@@ -3,13 +3,11 @@ import styled from 'styled-components';
 export const LoginPageLayout = styled.div`
   ${({ theme: { mixin } }) => mixin.flexCenter()};
   width: 100%;
-  height: 100vh;
-  background-color: rgb(208, 200, 200);
+  gap: 8rem;
+  margin-top: 16.6rem;
 `;
 
 export const LoginButton = styled.button`
   ${({ theme: { mixin } }) => mixin.flexBox({ align: 'flex-start' })};
-  width: 19.6875rem;
-  height: 3.4375rem;
   flex-shrink: 0;
 `;

--- a/src/pages/Login/Login.tsx
+++ b/src/pages/Login/Login.tsx
@@ -1,7 +1,7 @@
-import * as S from './Login.style';
 import OnboardingSection from '../../components/OnboardingSection/OnboardingSection';
 import IcKakaoLogin from '../../assets/svg/IcKakaoLogin';
 import { KAKAO_AUTH_URL } from '../../utils/login';
+import * as S from './Login.style';
 
 const Login = () => {
   const handleLogin = () => {

--- a/src/pages/Start/Start.style.ts
+++ b/src/pages/Start/Start.style.ts
@@ -3,12 +3,6 @@ import styled from 'styled-components';
 export const StartPageLayout = styled.div`
   ${({ theme: { mixin } }) => mixin.flexCenter()};
   width: 100%;
-  height: 100vh;
-  background-color: rgb(208, 200, 200);
-`;
-
-export const LoginSpaceBox = styled.div`
-  width: 19.6875rem;
-  height: 3.4375rem;
-  flex-shrink: 0;
+  gap: 8rem;
+  margin-top: 16.6rem;
 `;

--- a/src/pages/Start/Start.tsx
+++ b/src/pages/Start/Start.tsx
@@ -1,5 +1,6 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { getAccessToken } from '../../apis/client';
 import OnboardingSection from '../../components/OnboardingSection/OnboardingSection';
 import * as S from './Start.style';
 
@@ -8,11 +9,16 @@ const Start = () => {
 
   useEffect(() => {
     const timer = setTimeout(() => {
-      navigate('/login');
+      // access 토큰이 있는 경우 홈페이지로 리다이렉트
+      if (getAccessToken()) {
+        navigate('/home');
+      } else {
+        navigate('/login');
+      }
     }, 3000);
 
     return () => clearTimeout(timer);
-  });
+  }, []);
 
   return (
     <S.StartPageLayout>

--- a/src/pages/Start/Start.tsx
+++ b/src/pages/Start/Start.tsx
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import * as S from './Start.style';
 import OnboardingSection from '../../components/OnboardingSection/OnboardingSection';
+import * as S from './Start.style';
 
 const Start = () => {
   const navigate = useNavigate();
@@ -17,7 +17,6 @@ const Start = () => {
   return (
     <S.StartPageLayout>
       <OnboardingSection />
-      <S.LoginSpaceBox />
     </S.StartPageLayout>
   );
 };


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #42 

## 🪄작업 내용
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
>뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- 카카오 로그인 api 연동 코드 추가
- axios 인터셉터로 토큰 상태에 따른 에러 처리 구현
- 시작페이지에서 로그인 상태를 확인 후 리다이렉트


## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- 로그인 시 호출되는 fetchUser 함수의 경우 리스폰스로 유저 정보를 받아오긴 하지만, 앱 내에서 유저 정보를 조회하는 api와 응답 형식과 정보가 달라서 별도로 응답을 저장하지는 않도록 했습니다.
- 서버 구현에 따르면, access 토큰 만료시 내부에서 갱신 처리를 하고 `x-access-token`헤더에 갱신된 access 토큰 값을 보내준다고 합니다. 별도 에러를 던지지는 않기 때문에 로컬스토리지의 만료된 access 토큰 값을 갱신하기 위해서는 `x-access-token` 헤더로 보내준 값을 읽어와야 하는데, 현재는 읽히지 않는 상태입니다. 이 부분은 백엔드 측에 한번 더 문의해봐야 할 것 같습니다.

- env 파일에 VITE_BASE_URL을 서버 배포 URL로 설정하시면 로그인 테스트 가능합니다.! 
환경변수 설정: https://www.notion.so/bd76d375ce284b46be93f3afc0855f0d