### PR TITLE
[모멘트페이지] 버킷리스트 CRUD API 연동

### DIFF
--- a/src/components/Modal/CheckListModal/CheckListModal.tsx
+++ b/src/components/Modal/CheckListModal/CheckListModal.tsx
@@ -1,9 +1,9 @@
-import { CheckListType } from '../../../types/moment';
+import { BucketType } from '../../../types/moment';
 import IcCloseModal from '../../../assets/svg/IcCloseModal';
 import * as S from './CheckListModal.style';
 
 interface CheckListModalProps {
-  type: CheckListType;
+  type: BucketType;
   title: string;
   onClickEdit: () => void;
   onClickDelete: () => void;
@@ -33,7 +33,7 @@ const CheckListModal = ({
         <S.ModalOptionButton onClick={onClickCreate}>
           나만의 모멘트 생성
         </S.ModalOptionButton>
-        {type === '달성형' && (
+        {type === 'ACHIEVEMENT' && (
           <S.ModalOptionButton onClick={onClickUpload}>
             목표 달성 인증
           </S.ModalOptionButton>

--- a/src/components/Modal/OKModal/OKModal.tsx
+++ b/src/components/Modal/OKModal/OKModal.tsx
@@ -1,7 +1,7 @@
 import * as S from './OKModal.style';
 
 interface OKModalProps {
-  title: string;
+  title?: string;
   mainText: string;
   subText?: string;
   onClose: () => void;

--- a/src/components/Moment/CheckList/CheckList.tsx
+++ b/src/components/Moment/CheckList/CheckList.tsx
@@ -35,7 +35,6 @@ const CheckList = ({ type }: CheckListProps) => {
 
   useEffect(() => {
     if (data) {
-      console.log(data);
       setBucketList(data.buckets);
     }
   }, [data]);

--- a/src/components/Moment/CheckList/CheckList.tsx
+++ b/src/components/Moment/CheckList/CheckList.tsx
@@ -7,10 +7,15 @@ import IcCheckboxPending from '../../../assets/svg/IcCheckboxPending';
 import * as S from './CheckList.style';
 import usePostBucket from '../../../hooks/queries/bucketList/usePostBucket';
 import useResponseMessage from '../../../hooks/common/useErrorHandler';
+import usePatchBucket from '../../../hooks/queries/bucketList/usePatchBucket';
 
 // 목 데이터
 const bucketlist: BucketListType[] = [
-  { id: '1', title: '단어 500개 외우기', state: 'pending' },
+  {
+    id: '679c8ad644c09bba20cd248e',
+    title: '단어 500개 외우기',
+    state: 'pending',
+  },
   { id: '2', title: '컴활 1급 따기', state: 'pending' },
   { id: '3', title: '토익 800점 넘기', state: 'inProgress' },
   { id: '4', title: '오픽 AL 따기 ', state: 'completed' },
@@ -24,6 +29,7 @@ const CheckList = ({ type }: CheckListProps) => {
   const [bucketList, setBucketList] = useState<BucketListType[]>(bucketlist);
   const [newItem, setNewItem] = useState<string>('');
   const { mutate: postBucket } = usePostBucket();
+  const { mutate: patchBucket } = usePatchBucket();
   const { handleError, setMessage, openModal, renderModal } =
     useResponseMessage();
 
@@ -34,7 +40,7 @@ const CheckList = ({ type }: CheckListProps) => {
       if (!trimmedItem) return;
 
       const body = {
-        type: type,
+        type,
         content: trimmedItem,
       };
       postBucket(body, {
@@ -64,10 +70,23 @@ const CheckList = ({ type }: CheckListProps) => {
   };
 
   const handleUpdateItem = (id: string, newTitle: string) => {
-    setBucketList((prev) =>
-      prev.map((it) => (it.id === id ? { ...it, title: newTitle } : it)),
+    patchBucket(
+      { id, content: newTitle },
+      {
+        onSuccess: (data) => {
+          setMessage(data.message);
+          setBucketList((prev) =>
+            prev.map((it) => (it.id === id ? { ...it, title: newTitle } : it)),
+          );
+        },
+        onError: (error) => {
+          handleError(error);
+        },
+        onSettled: () => {
+          openModal();
+        },
+      },
     );
-    // 여기서 post api 요청
   };
 
   const handleDeleteItem = (id: string) => {

--- a/src/components/Moment/CheckList/CheckList.tsx
+++ b/src/components/Moment/CheckList/CheckList.tsx
@@ -10,6 +10,7 @@ import IcCheckboxPending from '../../../assets/svg/IcCheckboxPending';
 import * as S from './CheckList.style';
 import useGetRepeatBucket from '../../../hooks/queries/bucketList/useGetRepeatBucket';
 import useGetAchievementBucket from '../../../hooks/queries/bucketList/useGetAchievementBucket';
+import useDeleteBucket from '../../../hooks/queries/bucketList/useDeleteBucket';
 
 const TypeHooks = {
   REPEAT: useGetRepeatBucket,
@@ -27,6 +28,7 @@ const CheckList = ({ type }: CheckListProps) => {
     useResponseMessage();
   const { mutate: postBucket } = usePostBucket();
   const { mutate: patchBucket } = usePatchBucket();
+  const { mutate: deleteBucket } = useDeleteBucket();
 
   const useTypeHook = TypeHooks[type];
   const { data, isLoading } = useTypeHook();
@@ -98,8 +100,18 @@ const CheckList = ({ type }: CheckListProps) => {
   };
 
   const handleDeleteItem = (id: string) => {
-    setBucketList((prev) => prev.filter((it) => it.bucketID !== id));
-    // 여기서 delete api 요청
+    deleteBucket(id, {
+      onSuccess: (data) => {
+        setMessage(data.message);
+        setBucketList((prev) => prev.filter((it) => it.bucketID !== id));
+      },
+      onError: (error) => {
+        handleError(error);
+      },
+      onSettled: () => {
+        openModal();
+      },
+    });
   };
 
   if (!data || isLoading) {

--- a/src/components/Moment/CheckList/CheckList.tsx
+++ b/src/components/Moment/CheckList/CheckList.tsx
@@ -9,22 +9,11 @@ import CheckListItem from './CheckListItem/CheckListItem';
 import IcCheckboxPending from '../../../assets/svg/IcCheckboxPending';
 import * as S from './CheckList.style';
 import useGetRepeatBucket from '../../../hooks/queries/bucketList/useGetRepeatBucket';
-
-// 목 데이터
-// const bucketlist: BucketItemType[] = [
-//   {
-//     id: '679c8bd744c09bba20cd248f',
-//     title: '단어 500개 외우기',
-//     state: 'pending',
-//   },
-//   { id: '679c8ad644c09bba20cd248e', title: '컴활 1급 따기', state: 'pending' },
-//   { id: '3', title: '토익 800점 넘기', state: 'inProgress' },
-//   { id: '4', title: '오픽 AL 따기 ', state: 'completed' },
-// ];
+import useGetAchievementBucket from '../../../hooks/queries/bucketList/useGetAchievementBucket';
 
 const TypeHooks = {
   REPEAT: useGetRepeatBucket,
-  ACHIEVEMENT: useGetRepeatBucket,
+  ACHIEVEMENT: useGetAchievementBucket,
 };
 
 type CheckListProps = {

--- a/src/components/Moment/CheckList/CheckList.tsx
+++ b/src/components/Moment/CheckList/CheckList.tsx
@@ -1,22 +1,22 @@
 import { KeyboardEvent, useState } from 'react';
 import { handleResizeHeight } from '../../../utils/moment';
 import { BucketListType, BucketType } from '../../../types/moment';
+import usePostBucket from '../../../hooks/queries/bucketList/usePostBucket';
+import usePatchBucket from '../../../hooks/queries/bucketList/usePatchBucket';
+import useResponseMessage from '../../../hooks/common/useErrorHandler';
 import CheckListLayout from '../ContainerLayout/ContainerLayout';
 import CheckListItem from './CheckListItem/CheckListItem';
 import IcCheckboxPending from '../../../assets/svg/IcCheckboxPending';
 import * as S from './CheckList.style';
-import usePostBucket from '../../../hooks/queries/bucketList/usePostBucket';
-import useResponseMessage from '../../../hooks/common/useErrorHandler';
-import usePatchBucket from '../../../hooks/queries/bucketList/usePatchBucket';
 
 // 목 데이터
 const bucketlist: BucketListType[] = [
   {
-    id: '679c8ad644c09bba20cd248e',
+    id: '679c8bd744c09bba20cd248f',
     title: '단어 500개 외우기',
     state: 'pending',
   },
-  { id: '2', title: '컴활 1급 따기', state: 'pending' },
+  { id: '679c8ad644c09bba20cd248e', title: '컴활 1급 따기', state: 'pending' },
   { id: '3', title: '토익 800점 넘기', state: 'inProgress' },
   { id: '4', title: '오픽 AL 따기 ', state: 'completed' },
 ];

--- a/src/components/Moment/CheckList/CheckListItem/CheckListItem.tsx
+++ b/src/components/Moment/CheckList/CheckListItem/CheckListItem.tsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef, KeyboardEvent } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { ListItemType, StateType } from '../../../../types/moment';
+import { BucketType, StateType } from '../../../../types/moment';
 import useModal from '../../../../hooks/common/useModal';
 import Modal from '../../../Modal/Modal';
 import CheckListModal from '../../../Modal/CheckListModal/CheckListModal';
@@ -9,15 +9,27 @@ import IcCheckboxCompleted from '../../../../assets/svg/IcCheckboxCompleted';
 import IcCheckboxPending from '../../../../assets/svg/IcCheckboxPending';
 import * as S from './CheckListItem.style';
 
-interface CheckListItemProps {
-  id: number;
-  type: ListItemType;
+interface BucketTypeProps {
+  type: BucketType;
+  id: string;
+  state: StateType;
   value: string;
-  state: StateType | number;
   editState?: boolean;
-  onUpdateItem: (arg0: number, arg1: string) => void;
-  onDeleteItem?: (arg0: number) => void;
+  onUpdateItem: (id: string, value: string) => void;
+  onDeleteItem: (id: string) => void;
 }
+
+interface CreateTypeProps {
+  type: '생성형';
+  id: number;
+  state: number;
+  value: string;
+  editState: boolean;
+  onUpdateItem: (index: number, value: string) => void;
+  onDeleteItem?: () => void;
+}
+
+type CheckListItemProps = BucketTypeProps | CreateTypeProps;
 
 const StateIcons = {
   completed: <IcCheckboxCompleted />,
@@ -32,7 +44,7 @@ const CheckListItem = ({
   state,
   editState = false,
   onUpdateItem,
-  onDeleteItem = () => {},
+  onDeleteItem,
 }: CheckListItemProps) => {
   const [isOpen, openModal, closeModal] = useModal();
   const [isEditing, setIsEditing] = useState(editState);
@@ -54,8 +66,12 @@ const CheckListItem = ({
 
   const handleUpdateItem = () => {
     if (isEditing) {
-      onUpdateItem(id, itemValue);
-      if (type === '생성형') return;
+      if (type === '생성형') {
+        onUpdateItem(id as number, itemValue);
+        return;
+      } else {
+        onUpdateItem(id as string, itemValue);
+      }
       setIsEditing(false);
       alert(`${itemValue}저장`);
     }
@@ -74,6 +90,7 @@ const CheckListItem = ({
   };
 
   const hadleDeleteClick = () => {
+    if (type === '생성형') return;
     onDeleteItem(id);
     closeModal();
   };

--- a/src/components/Moment/CheckList/CheckListItem/CheckListItem.tsx
+++ b/src/components/Moment/CheckList/CheckListItem/CheckListItem.tsx
@@ -65,15 +65,16 @@ const CheckListItem = ({
   };
 
   const handleUpdateItem = () => {
-    if (isEditing) {
-      if (type === '생성형') {
-        onUpdateItem(id as number, itemValue);
-        return;
-      } else {
-        onUpdateItem(id as string, itemValue);
-      }
+    if (!isEditing) return;
+
+    if (type === '생성형') {
+      onUpdateItem(id as number, itemValue);
+    } else {
+      const trimmedValue = itemValue.trim();
+      if (!trimmedValue) return;
+
+      onUpdateItem(id as string, itemValue);
       setIsEditing(false);
-      alert(`${itemValue}저장`);
     }
   };
 

--- a/src/hooks/common/useErrorHandler.tsx
+++ b/src/hooks/common/useErrorHandler.tsx
@@ -11,7 +11,9 @@ const useResponseMessage = () => {
   const handleError = (error: Error) => {
     if (axios.isAxiosError(error)) {
       const errorMessage =
-        error.response?.data.message ?? '서버 연결에 실패하였습니다.';
+        error.response?.data.message ??
+        error.response?.data.error?.message ??
+        '서버 연결에 실패하였습니다.';
       setMessage(errorMessage);
     }
   };

--- a/src/hooks/common/useErrorHandler.tsx
+++ b/src/hooks/common/useErrorHandler.tsx
@@ -22,7 +22,7 @@ const useResponseMessage = () => {
     return (
       isOpen && (
         <Modal>
-          <OKModal title="" mainText={message} onClose={closeModal} />
+          <OKModal mainText={message} onClose={closeModal} />
         </Modal>
       )
     );

--- a/src/hooks/common/useErrorHandler.tsx
+++ b/src/hooks/common/useErrorHandler.tsx
@@ -1,19 +1,36 @@
 import axios from 'axios';
 import { useState } from 'react';
+import useModal from './useModal';
+import Modal from '../../components/Modal/Modal';
+import OKModal from '../../components/Modal/OKModal/OKModal';
 
 const useResponseMessage = () => {
   const [message, setMessage] = useState('');
+  const [isOpen, openModal, closeModal] = useModal();
 
   const handleError = (error: Error) => {
     if (axios.isAxiosError(error)) {
-      const errorMessage = error.response?.data.message;
+      const errorMessage =
+        error.response?.data.message ?? '서버 연결에 실패하였습니다.';
       setMessage(errorMessage);
     }
+  };
+
+  const renderModal = () => {
+    return (
+      isOpen && (
+        <Modal>
+          <OKModal title="" mainText={message} onClose={closeModal} />
+        </Modal>
+      )
+    );
   };
   return {
     handleError,
     message,
     setMessage,
+    openModal,
+    renderModal,
   };
 };
 

--- a/src/hooks/queries/bucketList/useDeleteBucket.tsx
+++ b/src/hooks/queries/bucketList/useDeleteBucket.tsx
@@ -1,0 +1,21 @@
+import { useMutation } from '@tanstack/react-query';
+import instance from '../../../apis/client';
+
+const deleteBucket = async (id: string) => {
+  const response = await instance.delete(`/api/bucket/${id}`);
+  return response.data;
+};
+
+const useDeleteBucket = () => {
+  return useMutation({
+    mutationFn: deleteBucket,
+    onSuccess: (data) => {
+      console.log(data);
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export default useDeleteBucket;

--- a/src/hooks/queries/bucketList/useDeleteBucket.tsx
+++ b/src/hooks/queries/bucketList/useDeleteBucket.tsx
@@ -1,14 +1,20 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import instance from '../../../apis/client';
+import { DeleteBucketResponse } from '../../../types/moment';
 
-const deleteBucket = async (id: string) => {
+const deleteBucket = async (id: string): Promise<DeleteBucketResponse> => {
   const response = await instance.delete(`/api/bucket/${id}`);
   return response.data;
 };
 
 const useDeleteBucket = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: deleteBucket,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['buckets', data.type] });
+    },
   });
 };
 

--- a/src/hooks/queries/bucketList/useDeleteBucket.tsx
+++ b/src/hooks/queries/bucketList/useDeleteBucket.tsx
@@ -9,12 +9,6 @@ const deleteBucket = async (id: string) => {
 const useDeleteBucket = () => {
   return useMutation({
     mutationFn: deleteBucket,
-    onSuccess: (data) => {
-      console.log(data);
-    },
-    onError: (error) => {
-      console.error(error);
-    },
   });
 };
 

--- a/src/hooks/queries/bucketList/useGetAchievementBucket.tsx
+++ b/src/hooks/queries/bucketList/useGetAchievementBucket.tsx
@@ -9,7 +9,7 @@ const getAchievementBucket = async (): Promise<GetBucketResponse> => {
 
 const useGetAchievementBucket = () =>
   useQuery({
-    queryKey: ['achievement-buckets'],
+    queryKey: ['buckets', 'ACHIEVEMENT'],
     queryFn: () => getAchievementBucket(),
   });
 

--- a/src/hooks/queries/bucketList/useGetAchievementBucket.tsx
+++ b/src/hooks/queries/bucketList/useGetAchievementBucket.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import instance from '../../../apis/client';
+import { GetBucketResponse } from '../../../types/moment';
+
+const getAchievementBucket = async (): Promise<GetBucketResponse> => {
+  const response = await instance.get(`/api/bucket/all/achievement`);
+  return response.data;
+};
+
+const useGetAchievementBucket = () =>
+  useQuery({
+    queryKey: ['achievement-buckets'],
+    queryFn: () => getAchievementBucket(),
+  });
+
+export default useGetAchievementBucket;

--- a/src/hooks/queries/bucketList/useGetBucketDetail.tsx
+++ b/src/hooks/queries/bucketList/useGetBucketDetail.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import instance from '../../../apis/client';
+import { BucketDetailResponse } from '../../../types/moment';
+
+const fetchBucketDetail = async (id: string): Promise<BucketDetailResponse> => {
+  const response = await instance.get(`/api/bucket/${id}`);
+  return response.data;
+};
+
+const useGetBucketDetail = (id: string) =>
+  useQuery({
+    queryKey: ['bucket', id],
+    queryFn: () => fetchBucketDetail(id),
+  });
+
+export default useGetBucketDetail;

--- a/src/hooks/queries/bucketList/useGetBucketDetail.tsx
+++ b/src/hooks/queries/bucketList/useGetBucketDetail.tsx
@@ -1,8 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import instance from '../../../apis/client';
-import { BucketDetailResponse } from '../../../types/moment';
+import { GetBucketDetailResponse } from '../../../types/moment';
 
-const fetchBucketDetail = async (id: string): Promise<BucketDetailResponse> => {
+const getBucketDetail = async (
+  id: string,
+): Promise<GetBucketDetailResponse> => {
   const response = await instance.get(`/api/bucket/${id}`);
   return response.data;
 };
@@ -10,7 +12,7 @@ const fetchBucketDetail = async (id: string): Promise<BucketDetailResponse> => {
 const useGetBucketDetail = (id: string) =>
   useQuery({
     queryKey: ['bucket', id],
-    queryFn: () => fetchBucketDetail(id),
+    queryFn: () => getBucketDetail(id),
   });
 
 export default useGetBucketDetail;

--- a/src/hooks/queries/bucketList/useGetRepeatBucket.tsx
+++ b/src/hooks/queries/bucketList/useGetRepeatBucket.tsx
@@ -9,7 +9,7 @@ const getRepeatBucket = async (): Promise<GetBucketResponse> => {
 
 const useGetRepeatBucket = () =>
   useQuery({
-    queryKey: ['repeat-buckets'],
+    queryKey: ['buckets', 'REPEAT'],
     queryFn: () => getRepeatBucket(),
   });
 

--- a/src/hooks/queries/bucketList/useGetRepeatBucket.tsx
+++ b/src/hooks/queries/bucketList/useGetRepeatBucket.tsx
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import instance from '../../../apis/client';
+import { GetBucketResponse } from '../../../types/moment';
+
+const getRepeatBucket = async (): Promise<GetBucketResponse> => {
+  const response = await instance.get(`/api/bucket/all/repeat`);
+  return response.data;
+};
+
+const useGetRepeatBucket = () =>
+  useQuery({
+    queryKey: ['repeat-buckets'],
+    queryFn: () => getRepeatBucket(),
+  });
+
+export default useGetRepeatBucket;

--- a/src/hooks/queries/bucketList/usePatchBucket.tsx
+++ b/src/hooks/queries/bucketList/usePatchBucket.tsx
@@ -1,0 +1,33 @@
+import { useMutation } from '@tanstack/react-query';
+import instance from '../../../apis/client';
+import { BucketResponse } from '../../../types/moment';
+
+interface PatchBucketParams {
+  id: string;
+  content: string;
+}
+
+// fetch 함수 작성
+const patchBucket = async ({
+  id,
+  content,
+}: PatchBucketParams): Promise<BucketResponse> => {
+  const response = await instance.patch(`/api/bucket/${id}`, {
+    content: content,
+  });
+  return response.data;
+};
+
+const usePatchBucket = () => {
+  return useMutation({
+    mutationFn: patchBucket,
+    onSuccess: (data) => {
+      console.log(data);
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export default usePatchBucket;

--- a/src/hooks/queries/bucketList/usePatchBucket.tsx
+++ b/src/hooks/queries/bucketList/usePatchBucket.tsx
@@ -1,4 +1,4 @@
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import instance from '../../../apis/client';
 import { UpdateBucketResponse } from '../../../types/moment';
 
@@ -18,8 +18,15 @@ const patchBucket = async ({
 };
 
 const usePatchBucket = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: patchBucket,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: ['buckets', data.bucket.type],
+      });
+    },
   });
 };
 

--- a/src/hooks/queries/bucketList/usePatchBucket.tsx
+++ b/src/hooks/queries/bucketList/usePatchBucket.tsx
@@ -7,7 +7,6 @@ interface PatchBucketParams {
   content: string;
 }
 
-// fetch 함수 작성
 const patchBucket = async ({
   id,
   content,

--- a/src/hooks/queries/bucketList/usePatchBucket.tsx
+++ b/src/hooks/queries/bucketList/usePatchBucket.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@tanstack/react-query';
 import instance from '../../../apis/client';
-import { BucketResponse } from '../../../types/moment';
+import { UpdateBucketResponse } from '../../../types/moment';
 
 interface PatchBucketParams {
   id: string;
@@ -10,7 +10,7 @@ interface PatchBucketParams {
 const patchBucket = async ({
   id,
   content,
-}: PatchBucketParams): Promise<BucketResponse> => {
+}: PatchBucketParams): Promise<UpdateBucketResponse> => {
   const response = await instance.patch(`/api/bucket/${id}`, {
     content: content,
   });

--- a/src/hooks/queries/bucketList/usePatchBucket.tsx
+++ b/src/hooks/queries/bucketList/usePatchBucket.tsx
@@ -20,12 +20,6 @@ const patchBucket = async ({
 const usePatchBucket = () => {
   return useMutation({
     mutationFn: patchBucket,
-    onSuccess: (data) => {
-      console.log(data);
-    },
-    onError: (error) => {
-      console.error(error);
-    },
   });
 };
 

--- a/src/hooks/queries/bucketList/usePatchBucketUpload.tsx
+++ b/src/hooks/queries/bucketList/usePatchBucketUpload.tsx
@@ -29,12 +29,6 @@ const patchBucketUpload = async ({
 const usePatchBucketUpload = () => {
   return useMutation({
     mutationFn: patchBucketUpload,
-    onSuccess: (data) => {
-      console.log(data);
-    },
-    onError: (error) => {
-      console.error(error);
-    },
   });
 };
 

--- a/src/hooks/queries/bucketList/usePatchBucketUpload.tsx
+++ b/src/hooks/queries/bucketList/usePatchBucketUpload.tsx
@@ -1,5 +1,5 @@
 import { useMutation } from '@tanstack/react-query';
-import { BucketResponse } from '../../../types/moment';
+import { UpdateBucketResponse } from '../../../types/moment';
 import instance from '../../../apis/client';
 
 interface PatchBucketUploadParams {
@@ -10,7 +10,7 @@ interface PatchBucketUploadParams {
 const patchBucketUpload = async ({
   id,
   image,
-}: PatchBucketUploadParams): Promise<BucketResponse> => {
+}: PatchBucketUploadParams): Promise<UpdateBucketResponse> => {
   const formData = new FormData();
   formData.append('photoUrl', image);
 

--- a/src/hooks/queries/bucketList/usePatchBucketUpload.tsx
+++ b/src/hooks/queries/bucketList/usePatchBucketUpload.tsx
@@ -1,0 +1,41 @@
+import { useMutation } from '@tanstack/react-query';
+import { BucketResponse } from '../../../types/moment';
+import instance from '../../../apis/client';
+
+interface PatchBucketUploadParams {
+  id: string;
+  image: string;
+}
+
+const patchBucketUpload = async ({
+  id,
+  image,
+}: PatchBucketUploadParams): Promise<BucketResponse> => {
+  const formData = new FormData();
+  formData.append('photoUrl', image);
+
+  const response = await instance.patch(
+    `/api/bucket/${id}/achievement-photo `,
+    formData,
+    {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    },
+  );
+  return response.data;
+};
+
+const usePatchBucketUpload = () => {
+  return useMutation({
+    mutationFn: patchBucketUpload,
+    onSuccess: (data) => {
+      console.log(data);
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export default usePatchBucketUpload;

--- a/src/hooks/queries/bucketList/usePostBucket.tsx
+++ b/src/hooks/queries/bucketList/usePostBucket.tsx
@@ -7,7 +7,6 @@ interface PostBucketParams {
   content: string;
 }
 
-// fetch 함수 작성
 const postBucket = async (body: PostBucketParams): Promise<BucketResponse> => {
   const response = await instance.post('/api/bucket', body);
   return response.data;

--- a/src/hooks/queries/bucketList/usePostBucket.tsx
+++ b/src/hooks/queries/bucketList/usePostBucket.tsx
@@ -1,5 +1,5 @@
 import { BucketType, UpdateBucketResponse } from '../../../types/moment';
-import { useMutation } from '@tanstack/react-query';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
 import instance from '../../../apis/client';
 
 interface PostBucketParams {
@@ -15,8 +15,15 @@ const postBucket = async (
 };
 
 const usePostBucket = () => {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: postBucket,
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({
+        queryKey: ['buckets', data.bucket.type],
+      });
+    },
   });
 };
 

--- a/src/hooks/queries/bucketList/usePostBucket.tsx
+++ b/src/hooks/queries/bucketList/usePostBucket.tsx
@@ -1,14 +1,14 @@
-import { BucketType, PostBucketResponse } from '../../../types/moment';
+import { BucketType, BucketResponse } from '../../../types/moment';
 import { useMutation } from '@tanstack/react-query';
 import instance from '../../../apis/client';
 
-interface BucketRequest {
+interface PostBucketParams {
   type: BucketType;
   content: string;
 }
 
 // fetch 함수 작성
-const postBucket = async (body: BucketRequest): Promise<PostBucketResponse> => {
+const postBucket = async (body: PostBucketParams): Promise<BucketResponse> => {
   const response = await instance.post('/api/bucket', body);
   return response.data;
 };

--- a/src/hooks/queries/bucketList/usePostBucket.tsx
+++ b/src/hooks/queries/bucketList/usePostBucket.tsx
@@ -1,4 +1,4 @@
-import { BucketType, BucketResponse } from '../../../types/moment';
+import { BucketType, UpdateBucketResponse } from '../../../types/moment';
 import { useMutation } from '@tanstack/react-query';
 import instance from '../../../apis/client';
 
@@ -7,7 +7,9 @@ interface PostBucketParams {
   content: string;
 }
 
-const postBucket = async (body: PostBucketParams): Promise<BucketResponse> => {
+const postBucket = async (
+  body: PostBucketParams,
+): Promise<UpdateBucketResponse> => {
   const response = await instance.post('/api/bucket', body);
   return response.data;
 };

--- a/src/hooks/queries/bucketList/usePostBucket.tsx
+++ b/src/hooks/queries/bucketList/usePostBucket.tsx
@@ -1,0 +1,28 @@
+import { BucketType, PostBucketResponse } from '../../../types/moment';
+import { useMutation } from '@tanstack/react-query';
+import instance from '../../../apis/client';
+
+interface BucketRequest {
+  type: BucketType;
+  content: string;
+}
+
+// fetch 함수 작성
+const postBucket = async (body: BucketRequest): Promise<PostBucketResponse> => {
+  const response = await instance.post('/api/bucket', body);
+  return response.data;
+};
+
+const usePostBucket = () => {
+  return useMutation({
+    mutationFn: postBucket,
+    onSuccess: (data) => {
+      console.log(data);
+    },
+    onError: (error) => {
+      console.error(error);
+    },
+  });
+};
+
+export default usePostBucket;

--- a/src/hooks/queries/bucketList/usePostBucket.tsx
+++ b/src/hooks/queries/bucketList/usePostBucket.tsx
@@ -17,12 +17,6 @@ const postBucket = async (
 const usePostBucket = () => {
   return useMutation({
     mutationFn: postBucket,
-    onSuccess: (data) => {
-      console.log(data);
-    },
-    onError: (error) => {
-      console.error(error);
-    },
   });
 };
 

--- a/src/pages/Moment/BucketList/BucketList.tsx
+++ b/src/pages/Moment/BucketList/BucketList.tsx
@@ -6,8 +6,8 @@ const BucketList = () => {
   return (
     <S.BucketListLayout>
       <MomentHeader />
-      <CheckList type="반복형" />
-      <CheckList type="달성형" />
+      <CheckList type="REPEAT" />
+      <CheckList type="ACHIEVEMENT" />
     </S.BucketListLayout>
   );
 };

--- a/src/pages/Moment/SelectMode.tsx
+++ b/src/pages/Moment/SelectMode.tsx
@@ -39,7 +39,7 @@ const SelectMode = () => {
       />
       <S.BtnContainer>
         <Button
-          customStyle={{
+          $customstyle={{
             width: '22rem',
             height: '5rem',
             backgroundColor: '#020202',
@@ -52,7 +52,7 @@ const SelectMode = () => {
           으로 생성할게요
         </Button>
         <Button
-          customStyle={{
+          $customstyle={{
             width: '22rem',
             height: '5rem',
             backgroundColor: '#020202',

--- a/src/pages/Moment/Upload/Upload.tsx
+++ b/src/pages/Moment/Upload/Upload.tsx
@@ -7,6 +7,7 @@ import OKModal from '../../../components/Modal/OKModal/OKModal';
 import Button from '../../../components/Button/Button';
 import IcBack from '../../../assets/svg/IcBack';
 import * as S from './Upload.style';
+import useGetBucketDetail from '../../../hooks/queries/bucketList/useGetBucketDetail';
 
 const mockData = {
   moment: {
@@ -26,23 +27,24 @@ type UploadProps = {
 };
 
 const Upload = ({ variant }: UploadProps) => {
+  const { id } = useParams();
   const [isOpen, openModal, closeModal] = useModal();
   const [image, setImage] = useState<string | null>(null);
-
   const navigate = useNavigate();
-  const { id } = useParams();
 
-  // 모멘트 세부 정보 조회 api 필요
-  // - 인증 완료 or 없는 id(4xx 에러) -> 리다이렉트 처리
-  // - 유효한 경우 모멘트/버킷리스트 title 가져오기
+  const { data, isError } = useGetBucketDetail(id || '');
 
   useEffect(() => {
-    // id 에러일 때 리다이렉트 임시 구현
-    if (id === 'none' || mockData[variant].isComplete) {
+    if (
+      isError ||
+      data?.bucket.isChallenging ||
+      data?.bucket.isCompleted ||
+      data?.bucket.type === 'REPEAT'
+    ) {
       alert('존재하지 않는 페이지입니다.');
       navigate('/moment');
     }
-  });
+  }, [data, isError, navigate]);
 
   const handleSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -65,7 +67,7 @@ const Upload = ({ variant }: UploadProps) => {
           <IcBack />
         </S.BackButton>
       </S.Header>
-      <S.TitleSpan>{mockData[variant].title}</S.TitleSpan>
+      <S.TitleSpan>{data?.bucket.content}</S.TitleSpan>
       <S.ImageUploadLayout onSubmit={handleSubmit}>
         <ImageUpload image={image} setImage={setImage} />
         <Button

--- a/src/types/moment/index.d.ts
+++ b/src/types/moment/index.d.ts
@@ -1,11 +1,5 @@
 export type StateType = 'completed' | 'inProgress' | 'pending';
 
-export interface BucketListType {
-  id: string;
-  title: string;
-  state: StateType;
-}
-
 export type BucketType = 'REPEAT' | 'ACHIEVEMENT';
 
 interface Bucket {
@@ -24,19 +18,34 @@ interface Bucket {
   userID: string;
 }
 
-export interface BucketResponse {
+interface BucketDetail extends Bucket {
+  moments: [];
+}
+
+export interface BucketItemType {
+  bucketID: string;
+  content: string;
+  isCompleted: boolean;
+  isChallenging: boolean;
+}
+
+export interface UpdateBucketResponse {
   bucket: Bucket;
   message: string;
   success: boolean;
 }
 
-interface BucketDetail extends Bucket {
-  moments: [];
-}
-
-export interface BucketDetailResponse {
+export interface GetBucketDetailResponse {
   bucket: BucketDetail;
   success: boolean;
   momentsCount: number;
   completedMomentsCount: number;
+}
+
+export interface GetBucketResponse {
+  success: boolean;
+  user: string;
+  count: number;
+  type: string;
+  buckets: BucketItemType[];
 }

--- a/src/types/moment/index.d.ts
+++ b/src/types/moment/index.d.ts
@@ -24,7 +24,7 @@ interface Bucket {
   userID: string;
 }
 
-interface PostBucketResponse {
+export interface BucketResponse {
   bucket: Bucket;
   message: string;
   success: boolean;

--- a/src/types/moment/index.d.ts
+++ b/src/types/moment/index.d.ts
@@ -13,12 +13,12 @@ interface Bucket {
   completedMomentsCount: number;
   content: string;
   createdAt: string;
-  endDate: null;
+  endDate: string;
   isChallenging: boolean;
   isCompleted: boolean;
   momentsCount: number;
-  photoUrl: null;
-  startDate: null;
+  photoUrl: null | string;
+  startDate: string;
   type: BucketType;
   updatedAt: string;
   userID: string;
@@ -28,4 +28,15 @@ export interface BucketResponse {
   bucket: Bucket;
   message: string;
   success: boolean;
+}
+
+interface BucketDetail extends Bucket {
+  moments: [];
+}
+
+export interface BucketDetailResponse {
+  bucket: BucketDetail;
+  success: boolean;
+  momentsCount: number;
+  completedMomentsCount: number;
 }

--- a/src/types/moment/index.d.ts
+++ b/src/types/moment/index.d.ts
@@ -2,24 +2,43 @@ export type StateType = 'completed' | 'inProgress' | 'pending';
 
 export type BucketType = 'REPEAT' | 'ACHIEVEMENT';
 
-interface Bucket {
+export type UploadType = 'moment' | 'bucket';
+
+export interface Bucket {
   bucketID: string;
   completedMomentsCount: number;
   content: string;
   createdAt: string;
-  endDate: string;
+  endDate: null | string;
   isChallenging: boolean;
   isCompleted: boolean;
   momentsCount: number;
   photoUrl: null | string;
-  startDate: string;
+  startDate: null | string;
   type: BucketType;
   updatedAt: string;
   userID: string;
 }
 
-interface BucketDetail extends Bucket {
-  moments: [];
+export interface Moment {
+  momentID: string;
+  content: string;
+  isCompleted: boolean;
+  photoUrl: null | string;
+  createdAt: string;
+  updatedAt: string;
+  startDate: string;
+  endDate: string;
+  bucketID: string;
+  userID: string;
+}
+
+export interface BucketDetail extends Bucket {
+  moments: Moment[];
+}
+
+export interface MomentDetail extends Moment {
+  bucket: Bucket;
 }
 
 export interface BucketItemType {
@@ -29,10 +48,19 @@ export interface BucketItemType {
   isChallenging: boolean;
 }
 
+// Response 타입
+
 export interface UpdateBucketResponse {
   bucket: Bucket;
   message: string;
   success: boolean;
+}
+
+export interface DeleteBucketResponse {
+  success: boolean;
+  message: string;
+  type: BucketType;
+  bucketID: string;
 }
 
 export interface GetBucketDetailResponse {
@@ -48,4 +76,9 @@ export interface GetBucketResponse {
   count: number;
   type: string;
   buckets: BucketItemType[];
+}
+
+export interface GetMomentDetailResponse {
+  success: boolean;
+  moment: MomentDetail;
 }

--- a/src/types/moment/index.d.ts
+++ b/src/types/moment/index.d.ts
@@ -1,10 +1,31 @@
 export type StateType = 'completed' | 'inProgress' | 'pending';
 
 export interface BucketListType {
-  id: number;
+  id: string;
   title: string;
   state: StateType;
 }
 
-export type CheckListType = '반복형' | '달성형';
-export type ListItemType = '생성형' | CheckListType;
+export type BucketType = 'REPEAT' | 'ACHIEVEMENT';
+
+interface Bucket {
+  bucketID: string;
+  completedMomentsCount: number;
+  content: string;
+  createdAt: string;
+  endDate: null;
+  isChallenging: boolean;
+  isCompleted: boolean;
+  momentsCount: number;
+  photoUrl: null;
+  startDate: null;
+  type: BucketType;
+  updatedAt: string;
+  userID: string;
+}
+
+interface PostBucketResponse {
+  bucket: Bucket;
+  message: string;
+  success: boolean;
+}

--- a/src/utils/moment.ts
+++ b/src/utils/moment.ts
@@ -5,3 +5,12 @@ export const handleResizeHeight = (e: FormEvent<HTMLTextAreaElement>) => {
   target.style.height = '20px';
   target.style.height = `${target.scrollHeight}px`;
 };
+
+export const setBucketState = (
+  isCompleted: boolean,
+  isChallenging: boolean,
+) => {
+  if (isCompleted) return 'completed';
+  if (isChallenging) return 'inProgress';
+  return 'pending';
+};


### PR DESCRIPTION
## #️⃣연관된 이슈
>PR과 연관된 이슈 번호를 작성해주세요. ex) #이슈 번호, #이슈 번호

- close: #58

## 🪄작업 내용
>해당 이슈 그리고 이번 PR에서 작업한 내용들을 작성해주세요.
>뷰 작업 내용이 포함되었을 경우 사진 혹은 동영상 파일 첨부를 부탁드립니다!

- "달성형", "반복형" 타입을 API 응답에 맞춰 "ACHIEVEMENT", "REPEAT"로 변경
- 버킷리스트 추가, 조회, 수정, 삭제 API 연동 완료
- 버킷리스트 달성 인증 API 연동 완료


## 💖리뷰 요청사항
>특별히 봐주셨으면 하는 부분, 나 좀 잘했다 하는 부분! 기타 당부의 말씀 등 자유롭게 작성해주세요.

- Upload 페이지에서 사용하는 useParams의 id 값이 타입 추론 시 string | undefined로 반환됩니다. (제네릭을 지정해도 동일) 하지만 저희 라우팅 구조상 id 파라미터가 없는 경우 Upload 컴포넌트가 렌더링되지 않고 다른 라우트로 이동합니다. 따라서 id가 undefined가 될 일이 없다고 생각해서 우선 type assertion 으로 처리했습니다. 다른 해결 방법이 있다면 의견 부탁 드립니다,,!!

- 에러 메세지가 API 마다 조금씩 다른 형태로 와서(HTML 형태로 오는 경우도 있음) `useResponseMessage` 훅에 errorMessage 할당하는 부분을 조금 수정했습니다. 추가로 `renderModal` 함수도 작성해두었습니다..!